### PR TITLE
Remove use of maven-assembly-plugin, it's not useful for a library.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -305,23 +305,6 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>2.22.0</version>
             </plugin>
-            <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <configuration>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
         </plugins>
     </build>
 


### PR DESCRIPTION
(And possibly is even broken, since it removes the BouncyCastle signature.)