### PR TITLE
update dependencies to latest stable versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <junit.version>5.5.1</junit.version>
-        <bouncycastle.version>1.61</bouncycastle.version>
+        <junit.version>5.6.2</junit.version>
+        <bouncycastle.version>1.65</bouncycastle.version>
     </properties>
 
     <profiles>
@@ -223,7 +223,7 @@
         <dependency>
             <groupId>org.jitsi</groupId>
             <artifactId>jitsi-utils</artifactId>
-            <version>1.0-9-gb8d9bee</version>
+            <version>1.0-44-gba9ad73</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
@@ -235,7 +235,12 @@
 	    <artifactId>bccontrib</artifactId>
 	    <version>1.0</version>
 	</dependency>
-
+    <dependency>
+        <groupId>org.jetbrains</groupId>
+        <artifactId>annotations</artifactId>
+        <version>19.0.0</version>
+        <optional>true</optional>
+    </dependency>
         <!-- test -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -252,7 +257,7 @@
 	<dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
-            <version>2.2.11</version>
+            <version>2.3.1</version>
             <scope>test</scope>
 	</dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -235,12 +235,12 @@
 	    <artifactId>bccontrib</artifactId>
 	    <version>1.0</version>
 	</dependency>
-    <dependency>
-        <groupId>org.jetbrains</groupId>
-        <artifactId>annotations</artifactId>
-        <version>19.0.0</version>
-        <optional>true</optional>
-    </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>19.0.0</version>
+            <optional>true</optional>
+        </dependency>
         <!-- test -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
         <dependency>
             <groupId>org.jitsi</groupId>
             <artifactId>jitsi-utils</artifactId>
-            <version>1.0-44-gba9ad73</version>
+            <version>1.0-45-gc3afb76</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
This PR simply updates the used dependencies to their latest stable versions. 😃 

Note that I removed 2 @NotNull annotations as these are specific for the intellij ide and the necessary transient dependency has been removed from jitsi-utils.

See https://www.jetbrains.com/help/idea/nullable-and-notnull-annotations.html

If the annotations should stay in place, we need to add:

```
<dependency>
    <groupId>org.jetbrains</groupId>
    <artifactId>annotations</artifactId>
    <version>19.0.0</version>
</dependency>
```