### PR TITLE
setup github actions for this repository

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,26 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # test against latest update of each major Java version, as well as specific updates of LTS versions:
+        java: [ 8, 11.0.x, 13 ]
+    name: Test build on  ${{ matrix.java }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup java
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - run: mvn clean -B test 


### PR DESCRIPTION
While the jenkins that is currently being used provides a nice and easy way for maintainers to see if the changes can be merged, it provides absolutely no information for the contributor.
(At least none that I'm aware of as a new contributor)

To improve this, this PR activates github actions for this repository.
This means that on each push and on each pull request it will automatically check if the tests are still working on java 8, 11 and 13.

This is not supposed to replace Jenkins, but it can help with reviews because the maintainer and the contributor get initial feedback on the PR immediately.
It's also free and does not interfere with the existing Jenkins at all 😄 

The name of the jobs and the executed commands can be changed of course. 😃 

See how it looks here: 
https://github.com/123Haynes/jitsi-srtp/actions
and here:
https://github.com/123Haynes/jitsi-srtp/pull/1