### PR TITLE
Remove bccontrib dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,11 +230,6 @@
             <artifactId>bcprov-jdk15on</artifactId>
             <version>${bouncycastle.version}</version>
         </dependency>
-	<dependency>
-	    <groupId>${project.groupId}</groupId>
-	    <artifactId>bccontrib</artifactId>
-	    <version>1.0</version>
-	</dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>

--- a/src/main/java/org/jitsi/srtp/BaseSrtpCryptoContext.java
+++ b/src/main/java/org/jitsi/srtp/BaseSrtpCryptoContext.java
@@ -34,11 +34,9 @@
 */
 package org.jitsi.srtp;
 
-import java.util.*;
-
 import org.bouncycastle.crypto.*;
 import org.bouncycastle.crypto.engines.*;
-import org.jitsi.bccontrib.macs.*;
+import org.bouncycastle.crypto.macs.*;
 import org.jitsi.srtp.crypto.*;
 import org.jitsi.utils.*;
 import org.jitsi.utils.logging2.*;
@@ -244,8 +242,8 @@ public class BaseSrtpCryptoContext
             break;
 
         case SrtpPolicy.SKEIN_AUTHENTICATION:
-            mac = new SkeinMac();
             tagStore = new byte[policy.getAuthTagLength()];
+            mac = new SkeinMac(SkeinMac.SKEIN_512, tagStore.length * 8);
             break;
 
         case SrtpPolicy.NULL_AUTHENTICATION:

--- a/src/main/java/org/jitsi/srtp/SrtcpCryptoContext.java
+++ b/src/main/java/org/jitsi/srtp/SrtcpCryptoContext.java
@@ -18,7 +18,6 @@ package org.jitsi.srtp;
 import java.util.*;
 
 import org.bouncycastle.crypto.params.*;
-import org.jitsi.bccontrib.params.*;
 import org.jitsi.srtp.utils.*;
 import org.jitsi.utils.*;
 import org.jitsi.utils.logging2.*;
@@ -153,23 +152,7 @@ public class SrtcpCryptoContext
         {
             byte[] authKey = new byte[policy.getAuthKeyLength()];
             kdf.deriveSessionKey(authKey, SrtpKdf.LABEL_RTCP_MSG_AUTH);
-
-            switch (policy.getAuthType())
-            {
-            case SrtpPolicy.HMACSHA1_AUTHENTICATION:
-                mac.init(new KeyParameter(authKey));
-                break;
-
-            case SrtpPolicy.SKEIN_AUTHENTICATION:
-                // Skein MAC uses number of bits as MAC size, not just bytes
-                mac.init(
-                        new ParametersForSkein(
-                                new KeyParameter(authKey),
-                                ParametersForSkein.Skein512,
-                                tagStore.length * 8));
-                break;
-            }
-
+            mac.init(new KeyParameter(authKey));
             Arrays.fill(authKey, (byte) 0);
         }
 

--- a/src/main/java/org/jitsi/srtp/SrtpCryptoContext.java
+++ b/src/main/java/org/jitsi/srtp/SrtpCryptoContext.java
@@ -37,7 +37,6 @@ package org.jitsi.srtp;
 import java.util.*;
 
 import org.bouncycastle.crypto.params.*;
-import org.jitsi.bccontrib.params.*;
 import org.jitsi.srtp.utils.*;
 import org.jitsi.utils.*;
 import org.jitsi.utils.logging2.*;
@@ -287,23 +286,7 @@ public class SrtpCryptoContext
         {
             byte[] authKey = new byte[policy.getAuthKeyLength()];
             kdf.deriveSessionKey(authKey, SrtpKdf.LABEL_RTP_MSG_AUTH);
-
-            switch (policy.getAuthType())
-            {
-                case SrtpPolicy.HMACSHA1_AUTHENTICATION:
-                    mac.init(new KeyParameter(authKey));
-                    break;
-
-                case SrtpPolicy.SKEIN_AUTHENTICATION:
-                    // Skein MAC uses number of bits as MAC size, not just bytes
-                    mac.init(
-                            new ParametersForSkein(
-                                    new KeyParameter(authKey),
-                                    ParametersForSkein.Skein512,
-                                    tagStore.length * 8));
-                    break;
-            }
-
+            mac.init(new KeyParameter(authKey));
             Arrays.fill(authKey, (byte) 0);
         }
 


### PR DESCRIPTION
Here its only used for Skein HMACs, but BouncyCastle meanwhile has
a Skein implementation. No need for contrib anymore.