### PR TITLE
Adjust SRTP crypto in non-OpenSSL cases.

### DIFF
--- a/src/main/java/org/jitsi/srtp/BaseSrtpCryptoContext.java
+++ b/src/main/java/org/jitsi/srtp/BaseSrtpCryptoContext.java
@@ -200,13 +200,9 @@ public class BaseSrtpCryptoContext
         case SrtpPolicy.NULL_ENCRYPTION:
             break;
 
-            /* TODO */
-        /*
         case SrtpPolicy.AESF8_ENCRYPTION:
-            cipherF8 = new SrtpCipherF8(Aes.createStreamCipher(encKeyLength));
+            cipherF8 = new SrtpCipherF8(Aes.createBlockCipher(encKeyLength));
             //$FALL-THROUGH$
-            */
-
 
         case SrtpPolicy.AESCM_ENCRYPTION:
             // use OpenSSL if available and AES128 is in use

--- a/src/main/java/org/jitsi/srtp/BaseSrtpCryptoContext.java
+++ b/src/main/java/org/jitsi/srtp/BaseSrtpCryptoContext.java
@@ -37,6 +37,7 @@ package org.jitsi.srtp;
 import org.bouncycastle.crypto.*;
 import org.bouncycastle.crypto.engines.*;
 import org.bouncycastle.crypto.macs.*;
+import org.bouncycastle.crypto.modes.*;
 import org.jitsi.srtp.crypto.*;
 import org.jitsi.utils.*;
 import org.jitsi.utils.logging2.*;
@@ -199,9 +200,13 @@ public class BaseSrtpCryptoContext
         case SrtpPolicy.NULL_ENCRYPTION:
             break;
 
+            /* TODO */
+        /*
         case SrtpPolicy.AESF8_ENCRYPTION:
-            cipherF8 = new SrtpCipherF8(Aes.createBlockCipher(encKeyLength));
+            cipherF8 = new SrtpCipherF8(Aes.createStreamCipher(encKeyLength));
             //$FALL-THROUGH$
+            */
+
 
         case SrtpPolicy.AESCM_ENCRYPTION:
             // use OpenSSL if available and AES128 is in use
@@ -212,8 +217,7 @@ public class BaseSrtpCryptoContext
             else
             {
                 cipherCtr
-                    = new SrtpCipherCtrJava(
-                            Aes.createBlockCipher(encKeyLength));
+                    = new SrtpCipherCtrJava(Aes.createStreamCipher(encKeyLength));
             }
             saltKey = new byte[saltKeyLength];
             break;
@@ -223,7 +227,7 @@ public class BaseSrtpCryptoContext
             //$FALL-THROUGH$
 
         case SrtpPolicy.TWOFISH_ENCRYPTION:
-            cipherCtr = new SrtpCipherCtrJava(new TwofishEngine());
+            cipherCtr = new SrtpCipherCtrJava(new SICBlockCipher(new TwofishEngine()));
             saltKey = new byte[saltKeyLength];
             break;
         }

--- a/src/main/java/org/jitsi/srtp/SrtpKdf.java
+++ b/src/main/java/org/jitsi/srtp/SrtpKdf.java
@@ -17,6 +17,7 @@
 package org.jitsi.srtp;
 
 import org.bouncycastle.crypto.engines.*;
+import org.bouncycastle.crypto.modes.*;
 import org.jitsi.srtp.crypto.*;
 
 import java.util.*;
@@ -85,15 +86,13 @@ class SrtpKdf
             }
             else
             {
-                cipherCtr
-                    = new SrtpCipherCtrJava(
-                    Aes.createBlockCipher(encKeyLength));
+                cipherCtr = new SrtpCipherCtrJava(Aes.createStreamCipher(encKeyLength));
             }
             break;
 
         case SrtpPolicy.TWOFISHF8_ENCRYPTION:
         case SrtpPolicy.TWOFISH_ENCRYPTION:
-            cipherCtr = new SrtpCipherCtrJava(new TwofishEngine());
+            cipherCtr = new SrtpCipherCtrJava(new SICBlockCipher(new TwofishEngine()));
             break;
 
         case SrtpPolicy.NULL_ENCRYPTION:

--- a/src/main/java/org/jitsi/srtp/crypto/Aes.java
+++ b/src/main/java/org/jitsi/srtp/crypto/Aes.java
@@ -34,7 +34,7 @@ public class Aes
 {
     /**
      * The block size in bytes of the AES algorithm (implemented by the
-     * <tt>BlockCipher</tt>s initialized by the <tt>Aes</tt> class).
+     * <tt>StreamCipher</tt>s initialized by the <tt>Aes</tt> class).
      */
     private static final int BLOCK_SIZE = 16;
 
@@ -61,14 +61,14 @@ public class Aes
 
     /**
      * The <tt>StreamCipherFactory</tt> implementation which is (to be) used by
-     * the class <tt>Aes</tt> to initialize <tt>BlockCipher</tt>s.
+     * the class <tt>Aes</tt> to initialize <tt>StreamCipher</tt>s.
      */
     private static StreamCipherFactory factory;
 
     /**
      * The name of the class to instantiate as a <tt>StreamCipherFactory</tt>
      * implementation to be used by the class <tt>Aes</tt> to initialize
-     * <tt>BlockCipher</tt>s.
+     * <tt>StreamCipher</tt>s.
      */
     private static String FACTORY_CLASS_NAME = null;
 
@@ -91,7 +91,7 @@ public class Aes
 
     /**
      * The class to instantiate as a <tt>StreamCipherFactory</tt> implementation
-     * to be used to initialized <tt>BlockCipher</tt>s.
+     * to be used to initialized <tt>StreamCipher</tt>s.
      *
      * @see #FACTORY_CLASS_NAME
      */
@@ -191,7 +191,7 @@ public class Aes
                 if (cipher == null)
                 {
                     // The StreamCipherFactory failed to initialize a new
-                    // BlockCipher instance. We will not use it again because
+                    // StreamCipher instance. We will not use it again because
                     // the failure may persist.
                     factories[f] = null;
                 }
@@ -256,7 +256,7 @@ public class Aes
      * Encryption Standard (AES) CTR mode.
      * @param keySize length of the AES key (16, 24, 32 bytes)
      *
-     * @return a new <tt>BlockCipher</tt> instance which implements Advanced
+     * @return a new <tt>StreamCipher</tt> instance which implements Advanced
      * Encryption Standard (AES) in the specified mode
      */
     public static StreamCipher createStreamCipher(int keySize)
@@ -274,7 +274,7 @@ public class Aes
             {
                 try
                 {
-                    factory = getBlockCipherFactory(keySize);
+                    factory = getStreamCipherFactory(keySize);
                 }
                 catch (Throwable t)
                 {
@@ -511,7 +511,7 @@ public class Aes
 
     /**
      * Gets a <tt>StreamCipherFactory</tt> instance to be used by the
-     * <tt>Aes</tt> class to initialize <tt>BlockCipher</tt>s.
+     * <tt>Aes</tt> class to initialize <tt>StreamCipher</tt>s.
      *
      * <p>
      * Benchmarks the well-known <tt>StreamCipherFactory</tt> implementations and
@@ -520,9 +520,9 @@ public class Aes
      * @param keySize AES key size (16, 24, 32 bytes)
      *
      * @return a <tt>StreamCipherFactory</tt> instance to be used by the
-     * <tt>Aes</tt> class to initialize <tt>BlockCipher</tt>s
+     * <tt>Aes</tt> class to initialize <tt>StreamCipher</tt>s
      */
-    private static StreamCipherFactory getBlockCipherFactory(int keySize)
+    private static StreamCipherFactory getStreamCipherFactory(int keySize)
     {
         StreamCipherFactory[] factories = Aes.factories;
 
@@ -534,8 +534,8 @@ public class Aes
             Aes.factories = factories = createStreamCipherFactories();
         }
 
-        // Benchmark the BlockCiphers provided by the available
-        // BlockCipherFactories in order to select the fastest-performing
+        // Benchmark the StreamCiphers provided by the available
+        // StreamCipherFactories in order to select the fastest-performing
         // StreamCipherFactory.
         StreamCipherFactory minFactory = benchmark(factories, keySize);
 

--- a/src/main/java/org/jitsi/srtp/crypto/Aes.java
+++ b/src/main/java/org/jitsi/srtp/crypto/Aes.java
@@ -119,7 +119,7 @@ public class Aes
     /**
      * The output buffer to be used for the benchmarking of {@link #factories}.
      */
-    private static final byte[] out = new byte[BLOCK_SIZE];
+    private static final byte[] out = new byte[BLOCK_SIZE * 1024];
 
     /**
      * The random number generator which generates keys and inputs for the
@@ -151,12 +151,14 @@ public class Aes
     {
         Random random = Aes.random;
         byte[] key = new byte[keySize];
+        byte[] iv = new byte[BLOCK_SIZE];
         byte[] in = Aes.in;
 
         random.nextBytes(key);
+        random.nextBytes(iv);
         random.nextBytes(in);
 
-        CipherParameters params = new KeyParameter(key);
+        CipherParameters params = new ParametersWithIV(new KeyParameter(key), iv);
         int blockSize = BLOCK_SIZE;
         int inEnd = in.length - blockSize + 1;
         byte[] out = Aes.out;

--- a/src/main/java/org/jitsi/srtp/crypto/Aes.java
+++ b/src/main/java/org/jitsi/srtp/crypto/Aes.java
@@ -20,10 +20,15 @@ import java.security.*;
 import java.util.*;
 
 import org.bouncycastle.crypto.*;
+import org.bouncycastle.crypto.digests.*;
 import org.bouncycastle.crypto.engines.*;
+import org.bouncycastle.crypto.macs.*;
 import org.bouncycastle.crypto.modes.*;
 import org.bouncycastle.crypto.params.*;
 import org.jitsi.utils.logging2.*;
+
+import javax.crypto.*;
+import javax.crypto.Mac;
 
 /**
  * Implements a factory for an AES/CTR <tt>StreamCipher</tt>.
@@ -252,12 +257,38 @@ public class Aes
     }
 
     /**
+     * Initializes a new <tt>Blockipher</tt> instance which implements Advanced
+     * Encryption Standard (AES) ECB mode.
+     * @param keySize length of the AES key (16, 24, 32 bytes)
+     *
+     * @return a new <tt>StreamCipher</tt> instance which implements Advanced
+     * Encryption Standard (AES) in ECB mode
+     */
+    public static BlockCipher createBlockCipher(int keySize)
+    {
+        /* Note: Since jitsi-srtp only uses this mode for the AES-F8 cipher,
+         * which is pretty obscure, we don't do the whole benchmarking logic
+         * like we do for createStreamCipher; instead, we just use the provider
+         * chosen by JCE, or BouncyCastle if none.
+         */
+        try
+        {
+            Cipher cipher = Cipher.getInstance("AES/ECB/NoPadding");
+            return new BlockCipherAdapter(cipher, logger);
+        }
+        catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
+            // Fallback to BouncyCastle
+            return new AESEngine();
+        }
+    }
+
+    /**
      * Initializes a new <tt>StreamCipher</tt> instance which implements Advanced
      * Encryption Standard (AES) CTR mode.
      * @param keySize length of the AES key (16, 24, 32 bytes)
      *
      * @return a new <tt>StreamCipher</tt> instance which implements Advanced
-     * Encryption Standard (AES) in the specified mode
+     * Encryption Standard (AES) in CTR mode
      */
     public static StreamCipher createStreamCipher(int keySize)
     {

--- a/src/main/java/org/jitsi/srtp/crypto/Aes.java
+++ b/src/main/java/org/jitsi/srtp/crypto/Aes.java
@@ -257,7 +257,7 @@ public class Aes
     }
 
     /**
-     * Initializes a new <tt>Blockipher</tt> instance which implements Advanced
+     * Initializes a new <tt>BlockCipher</tt> instance which implements Advanced
      * Encryption Standard (AES) ECB mode.
      * @param keySize length of the AES key (16, 24, 32 bytes)
      *

--- a/src/main/java/org/jitsi/srtp/crypto/Aes.java
+++ b/src/main/java/org/jitsi/srtp/crypto/Aes.java
@@ -159,8 +159,6 @@ public class Aes
         random.nextBytes(in);
 
         CipherParameters params = new ParametersWithIV(new KeyParameter(key), iv);
-        int blockSize = BLOCK_SIZE;
-        int inEnd = in.length - blockSize + 1;
         byte[] out = Aes.out;
         long minTime = Long.MAX_VALUE;
         StreamCipherFactory minFactory = null;

--- a/src/main/java/org/jitsi/srtp/crypto/Aes.java
+++ b/src/main/java/org/jitsi/srtp/crypto/Aes.java
@@ -28,7 +28,6 @@ import org.bouncycastle.crypto.params.*;
 import org.jitsi.utils.logging2.*;
 
 import javax.crypto.*;
-import javax.crypto.Mac;
 
 /**
  * Implements a factory for an AES/CTR <tt>StreamCipher</tt>.

--- a/src/main/java/org/jitsi/srtp/crypto/BlockCipherAdapter.java
+++ b/src/main/java/org/jitsi/srtp/crypto/BlockCipherAdapter.java
@@ -21,12 +21,13 @@ import javax.crypto.*;
 import javax.crypto.spec.*;
 
 import org.bouncycastle.crypto.*;
+import org.bouncycastle.crypto.modes.*;
 import org.bouncycastle.crypto.params.*;
 import org.jitsi.utils.logging2.*;
 
 /**
- * Adapts the <tt>javax.crypto.Cipher</tt> class to the
- * <tt>org.bouncycastle.crypto.BlockCipher</tt> interface. 
+ * Adapts the {@link javax.crypto.Cipher} class to the
+ * {@link org.bouncycastle.crypto.BlockCipher} interface.
  *
  * @author Lyubomir Marinov
  */
@@ -50,18 +51,18 @@ public class BlockCipherAdapter
     private final int blockSize;
 
     /**
-     * The <tt>javax.crypto.Cipher</tt> instance which is adapted to the
-     * <tt>org.bouncycastle.crypto.BlockCipher</tt> interface by this instance.
+     * The {@link javax.crypto.Cipher} instance which is adapted to the
+     * {@link org.bouncycastle.crypto.BlockCipher} interface by this instance.
      */
     private final Cipher cipher;
 
     /**
      * Initializes a new <tt>BlockCipherAdapter</tt> instance which is to adapt
-     * a specific <tt>javax.crypto.Cipher</tt> instance to the
-     * <tt>org.bouncycastle.crypto.BlockCipher</tt> interface.
+     * a specific {@link javax.crypto.Cipher} instance to the
+     * {@link org.bouncycastle.crypto.BlockCipher} interface.
      *
-     * @param cipher the <tt>javax.crypto.Cipher</tt> instance to be adapted to
-     * the <tt>org.bouncycastle.crypto.BlockCipher</tt> interface by the new
+     * @param cipher the {@link javax.crypto.Cipher} instance to be adapted to
+     * the {@link org.bouncycastle.crypto.BlockCipher} interface by the new
      * instance
      */
     public BlockCipherAdapter(Cipher cipher, Logger parentLogger)
@@ -118,11 +119,11 @@ public class BlockCipherAdapter
     }
 
     /**
-     * Gets the <tt>javax.crypto.Cipher</tt> instance which is adapted to the
-     * <tt>org.bouncycastle.crypto.BlockCipher</tt> interface by this instance.
+     * Gets the {@link javax.crypto.Cipher} instance which is adapted to the
+     * {@link org.bouncycastle.crypto.BlockCipher} interface by this instance.
      *
-     * @return the <tt>javax.crypto.Cipher</tt> instance which is adapted to the
-     * <tt>org.bouncycastle.crypto.BlockCipher</tt> interface by this instance
+     * @return the {@link javax.crypto.Cipher} instance which is adapted to the
+     * {@link org.bouncycastle.crypto.BlockCipher} interface by this instance
      */
     public Cipher getCipher()
     {

--- a/src/main/java/org/jitsi/srtp/crypto/HmacSha1.java
+++ b/src/main/java/org/jitsi/srtp/crypto/HmacSha1.java
@@ -54,7 +54,6 @@ public class HmacSha1
             try
             {
                 Mac mac = Mac.getInstance("HmacSHA1");
-                logger.info("Using HmacSHA1 from provider " + mac.getProvider().getName());
                 return new MacAdapter(mac);
             }
             catch (NoSuchAlgorithmException e) {

--- a/src/main/java/org/jitsi/srtp/crypto/HmacSha1.java
+++ b/src/main/java/org/jitsi/srtp/crypto/HmacSha1.java
@@ -15,9 +15,10 @@
  */
 package org.jitsi.srtp.crypto;
 
-import org.bouncycastle.crypto.*;
 import org.bouncycastle.crypto.digests.*;
 import org.bouncycastle.crypto.macs.*;
+import javax.crypto.*;
+import java.security.*;
 
 /**
  * Implements a factory for an HMAC-SHA1 <tt>org.bouncycastle.crypto.Mac</tt>.
@@ -33,7 +34,7 @@ public class HmacSha1
      * @return a new <tt>org.bouncycastle.crypto.Mac</tt> instance which
      * implements a keyed-hash message authentication code (HMAC) with SHA-1
      */
-    public static Mac createMac()
+    public static org.bouncycastle.crypto.Mac createMac()
     {
         if (OpenSslWrapperLoader.isLoaded())
         {
@@ -41,8 +42,15 @@ public class HmacSha1
         }
         else
         {
-            // Fallback to BouncyCastle.
-            return new HMac(new SHA1Digest());
+            // Fallback to JCE.
+            try
+            {
+                return new MacAdapter(Mac.getInstance("HmacSHA1"));
+            }
+            catch (NoSuchAlgorithmException e) {
+                /* Boom */
+                throw new IllegalStateException(e);
+            }
         }
     }
 }

--- a/src/main/java/org/jitsi/srtp/crypto/HmacSha1.java
+++ b/src/main/java/org/jitsi/srtp/crypto/HmacSha1.java
@@ -53,8 +53,7 @@ public class HmacSha1
             // Fallback to JCE.
             try
             {
-                Mac mac = Mac.getInstance("HmacSHA1");
-                return new MacAdapter(mac);
+                return new MacAdapter(javax.crypto.Mac.getInstance("HmacSHA1"));
             }
             catch (NoSuchAlgorithmException e) {
                 // Fallback to BouncyCastle

--- a/src/main/java/org/jitsi/srtp/crypto/HmacSha1.java
+++ b/src/main/java/org/jitsi/srtp/crypto/HmacSha1.java
@@ -17,6 +17,8 @@ package org.jitsi.srtp.crypto;
 
 import org.bouncycastle.crypto.digests.*;
 import org.bouncycastle.crypto.macs.*;
+import org.jitsi.utils.logging2.*;
+
 import javax.crypto.*;
 import java.security.*;
 
@@ -27,6 +29,12 @@ import java.security.*;
  */
 public class HmacSha1
 {
+    /**
+     * The <tt>Logger</tt> used by the <tt>Aes</tt> class to print out debug
+     * information.
+     */
+    private static final Logger logger = new LoggerImpl(HmacSha1.class.getName());
+
     /**
      * Initializes a new <tt>org.bouncycastle.crypto.Mac</tt> instance which
      * implements a keyed-hash message authentication code (HMAC) with SHA-1.
@@ -45,11 +53,13 @@ public class HmacSha1
             // Fallback to JCE.
             try
             {
-                return new MacAdapter(Mac.getInstance("HmacSHA1"));
+                Mac mac = Mac.getInstance("HmacSHA1");
+                logger.info("Using HmacSHA1 from provider " + mac.getProvider().getName());
+                return new MacAdapter(mac);
             }
             catch (NoSuchAlgorithmException e) {
-                /* Boom */
-                throw new IllegalStateException(e);
+                // Fallback to BouncyCastle
+                return new HMac(new SHA1Digest());
             }
         }
     }

--- a/src/main/java/org/jitsi/srtp/crypto/MacAdapter.java
+++ b/src/main/java/org/jitsi/srtp/crypto/MacAdapter.java
@@ -23,17 +23,45 @@ import javax.crypto.spec.*;
 import java.security.*;
 
 /**
- * Adapts the <tt>javax.crypto.Mac</tt> class to the
- * <tt>org.bouncycastle.crypto.Mac</tt> interface.
+ * Adapts the {@link javax.crypto.Mac} class to the
+ * {@link org.bouncycastle.crypto.Mac} interface.
  */
 public class MacAdapter implements org.bouncycastle.crypto.Mac
 {
+    /**
+     * The {@link javax.crypto.Mac} instance which is adapted to the
+     * {@link org.bouncycastle.crypto.Mac} interface by this instance.
+     */
     private final javax.crypto.Mac mac;
 
+    /**
+     * Initializes a new <tt>MacAdapter</tt> instance which is to adapt
+     * a specific {@link javax.crypto.Mac} instance to the
+     * {@link org.bouncycastle.crypto.Mac} interface.
+     *
+     * @param mac the {@link javax.crypto.Mac} instance to be adapted to
+     * the {@link org.bouncycastle.crypto.Mac} interface by the new
+     * instance
+     */
     public MacAdapter(javax.crypto.Mac mac) {
         this.mac = mac;
     }
 
+    /**
+     * Gets the {@link javax.crypto.Mac} instance which is adapted to the
+     * {@link org.bouncycastle.crypto.Mac} interface by this instance.
+     *
+     * @return the {@link javax.crypto.Mac} instance which is adapted to the
+     * {@link org.bouncycastle.crypto.Mac} interface by this instance
+     */
+    public javax.crypto.Mac getJavaxMac()
+    {
+        return mac;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void init(CipherParameters params) throws IllegalArgumentException
     {
@@ -52,24 +80,36 @@ public class MacAdapter implements org.bouncycastle.crypto.Mac
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String getAlgorithmName()
     {
         return mac.getAlgorithm();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public int getMacSize()
     {
         return mac.getMacLength();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void update(byte in) throws IllegalStateException
     {
         mac.update(in);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void update(byte[] in, int inOff, int len)
         throws DataLengthException, IllegalStateException
@@ -77,6 +117,9 @@ public class MacAdapter implements org.bouncycastle.crypto.Mac
         mac.update(in, inOff, len);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public int doFinal(byte[] out, int outOff)
         throws DataLengthException, IllegalStateException
@@ -91,6 +134,9 @@ public class MacAdapter implements org.bouncycastle.crypto.Mac
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void reset()
     {

--- a/src/main/java/org/jitsi/srtp/crypto/MacAdapter.java
+++ b/src/main/java/org/jitsi/srtp/crypto/MacAdapter.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright @ 2020 - present 8x8, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.srtp.crypto;
+
+import org.bouncycastle.crypto.*;
+import org.bouncycastle.crypto.params.*;
+
+import javax.crypto.*;
+import javax.crypto.spec.*;
+import java.security.*;
+
+/**
+ * Adapts the <tt>javax.crypto.Mac</tt> class to the
+ * <tt>org.bouncycastle.crypto.Mac</tt> interface.
+ */
+public class MacAdapter implements org.bouncycastle.crypto.Mac
+{
+    private final javax.crypto.Mac mac;
+
+    public MacAdapter(javax.crypto.Mac mac) {
+        this.mac = mac;
+    }
+
+    @Override
+    public void init(CipherParameters params) throws IllegalArgumentException
+    {
+        byte[] key = (params instanceof KeyParameter)
+            ? ((KeyParameter) params).getKey()
+            : null;
+
+        SecretKey secretKey = new SecretKeySpec(key, mac.getAlgorithm());
+
+        try
+        {
+            mac.init(secretKey);
+        }
+        catch (InvalidKeyException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    @Override
+    public String getAlgorithmName()
+    {
+        return mac.getAlgorithm();
+    }
+
+    @Override
+    public int getMacSize()
+    {
+        return mac.getMacLength();
+    }
+
+    @Override
+    public void update(byte in) throws IllegalStateException
+    {
+        mac.update(in);
+    }
+
+    @Override
+    public void update(byte[] in, int inOff, int len)
+        throws DataLengthException, IllegalStateException
+    {
+        mac.update(in, inOff, len);
+    }
+
+    @Override
+    public int doFinal(byte[] out, int outOff)
+        throws DataLengthException, IllegalStateException
+    {
+        try
+        {
+            mac.doFinal(out, outOff);
+            return mac.getMacLength();
+        }
+        catch (ShortBufferException e) {
+            throw new DataLengthException(e.getMessage());
+        }
+    }
+
+    @Override
+    public void reset()
+    {
+        mac.reset();
+    }
+}

--- a/src/main/java/org/jitsi/srtp/crypto/SecurityProviderStreamCipherFactory.java
+++ b/src/main/java/org/jitsi/srtp/crypto/SecurityProviderStreamCipherFactory.java
@@ -25,7 +25,7 @@ import org.jitsi.utils.logging2.*;
 
 /**
  * Implements a <tt>StreamCipherFactory</tt> which initializes
- * <tt>BlockCipher</tt>s that are implemented by a
+ * <tt>StreamCipher</tt>s that are implemented by a
  * <tt>java.security.Provider</tt>.
  *
  * @author Lyubomir Marinov
@@ -35,7 +35,7 @@ public class SecurityProviderStreamCipherFactory
 {
     /**
      * The <tt>java.security.Provider</tt> which provides the implementations of
-     * the <tt>BlockCipher</tt>s to be initialized by this instance.
+     * the <tt>StreamCipher</tt>s to be initialized by this instance.
      */
     private final Provider provider;
 
@@ -52,12 +52,12 @@ public class SecurityProviderStreamCipherFactory
 
     /**
      * Initializes a new <tt>SecurityProvider</tt> instance which is to
-     * initialize <tt>BlockCipher</tt>s that are implemented by a specific
+     * initialize <tt>StreamCipher</tt>s that are implemented by a specific
      * <tt>java.security.Provider</tt>.
      *
      * @param transformation the name of the transformation
      * @param provider the <tt>java.security.Provider</tt> which provides the
-     * implementations of the <tt>BlockCipher</tt>s to be initialized by the new
+     * implementations of the <tt>StreamCipher</tt>s to be initialized by the new
      * instance
      */
     public SecurityProviderStreamCipherFactory(
@@ -79,12 +79,12 @@ public class SecurityProviderStreamCipherFactory
 
     /**
      * Initializes a new <tt>SecurityProvider</tt> instance which is to
-     * initialize <tt>BlockCipher</tt>s that are implemented by a specific
+     * initialize <tt>StreamCipher</tt>s that are implemented by a specific
      * <tt>java.security.Provider</tt>.
      *
      * @param transformation the name of the transformation
      * @param providerName the name of the <tt>java.security.Provider</tt> which
-     * provides the implementations of the <tt>BlockCipher</tt>s to be
+     * provides the implementations of the <tt>StreamCipher</tt>s to be
      * initialized by the new instance
      */
     public SecurityProviderStreamCipherFactory(
@@ -105,11 +105,7 @@ public class SecurityProviderStreamCipherFactory
     {
         return
             new StreamCipherAdapter(
-                    Cipher.getInstance(
-                            transformation.replaceFirst(
-                                    "<size>",
-                                    Integer.toString(keySize * 8)),
-                            provider),
+                    Cipher.getInstance(transformation, provider),
                 logger);
     }
 }

--- a/src/main/java/org/jitsi/srtp/crypto/SecurityProviderStreamCipherFactory.java
+++ b/src/main/java/org/jitsi/srtp/crypto/SecurityProviderStreamCipherFactory.java
@@ -21,18 +21,17 @@ import javax.crypto.*;
 
 import org.bouncycastle.crypto.*;
 import org.jetbrains.annotations.*;
-import org.jitsi.srtp.crypto.*;
 import org.jitsi.utils.logging2.*;
 
 /**
- * Implements a <tt>BlockCipherFactory</tt> which initializes
+ * Implements a <tt>StreamCipherFactory</tt> which initializes
  * <tt>BlockCipher</tt>s that are implemented by a
  * <tt>java.security.Provider</tt>.
  *
  * @author Lyubomir Marinov
  */
-public class SecurityProviderBlockCipherFactory
-    implements BlockCipherFactory
+public class SecurityProviderStreamCipherFactory
+    implements StreamCipherFactory
 {
     /**
      * The <tt>java.security.Provider</tt> which provides the implementations of
@@ -61,7 +60,7 @@ public class SecurityProviderBlockCipherFactory
      * implementations of the <tt>BlockCipher</tt>s to be initialized by the new
      * instance
      */
-    public SecurityProviderBlockCipherFactory(
+    public SecurityProviderStreamCipherFactory(
             String transformation,
             Provider provider,
             @NotNull Logger parentLogger)
@@ -88,7 +87,7 @@ public class SecurityProviderBlockCipherFactory
      * provides the implementations of the <tt>BlockCipher</tt>s to be
      * initialized by the new instance
      */
-    public SecurityProviderBlockCipherFactory(
+    public SecurityProviderStreamCipherFactory(
             String transformation,
             String providerName,
             @NotNull Logger parentLogger)
@@ -98,13 +97,14 @@ public class SecurityProviderBlockCipherFactory
 
     /**
      * {@inheritDoc}
+     * @return
      */
     @Override
-    public BlockCipher createBlockCipher(int keySize)
+    public StreamCipher createStreamCipher(int keySize)
         throws Exception
     {
         return
-            new BlockCipherAdapter(
+            new StreamCipherAdapter(
                     Cipher.getInstance(
                             transformation.replaceFirst(
                                     "<size>",

--- a/src/main/java/org/jitsi/srtp/crypto/SrtpCipherCtrJava.java
+++ b/src/main/java/org/jitsi/srtp/crypto/SrtpCipherCtrJava.java
@@ -26,7 +26,6 @@ import org.bouncycastle.crypto.params.*;
  */
 public class SrtpCipherCtrJava extends SrtpCipherCtr
 {
-    private final byte[] tmpCipherBlock = new byte[BLKLEN];
     private final StreamCipher cipher;
 
     private static final byte[] zeroIV = new byte[BLKLEN];

--- a/src/main/java/org/jitsi/srtp/crypto/SrtpCipherCtrJava.java
+++ b/src/main/java/org/jitsi/srtp/crypto/SrtpCipherCtrJava.java
@@ -22,8 +22,7 @@ import org.bouncycastle.crypto.params.*;
  * @see SrtpCipherCtr
  * SrtpCipherCtr implementation using Java and a {@link StreamCipher}.
  *
- * You can use any <tt>BlockCipher</tt> with <tt>BLKLEN</tt> bytes key and
- * block size like TwofishEngine instead of AES.
+ * You can use any <tt>StreamCipher</tt> like TwofishEngine/CTR instead of AES.
  */
 public class SrtpCipherCtrJava extends SrtpCipherCtr
 {

--- a/src/main/java/org/jitsi/srtp/crypto/StreamCipherAdapter.java
+++ b/src/main/java/org/jitsi/srtp/crypto/StreamCipherAdapter.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright @ 2015 - present 8x8, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.srtp.crypto;
+
+import org.bouncycastle.crypto.*;
+import org.bouncycastle.crypto.params.*;
+import org.jitsi.utils.logging2.*;
+
+import javax.crypto.*;
+import javax.crypto.spec.*;
+import java.security.*;
+
+/**
+ * Adapts the {@link javax.crypto.Cipher} class to the
+ * {@link org.bouncycastle.crypto.BlockCipher} interface.
+ *
+ * @author Lyubomir Marinov
+ */
+public class StreamCipherAdapter
+    implements StreamCipher
+{
+    /**
+     * The name of the cipher used by this instance.
+     */
+    private final String cipherName;
+
+    /**
+     * The name of the algorithm implemented by this instance.
+     */
+    private final String algorithmName;
+
+    /**
+     * The {@link javax.crypto.Cipher} instance which is adapted to the
+     * {@link org.bouncycastle.crypto.StreamCipher} interface by this instance.
+     */
+    private final Cipher cipher;
+
+    /**
+     * Initializes a new <tt>StreamCipherAdapter</tt> instance which is to adapt
+     * a specific {@link javax.crypto.Cipher} instance to the
+     * {@link org.bouncycastle.crypto.StreamCipher} interface.
+     *
+     * @param cipher the {@link javax.crypto.Cipher} instance to be adapted to
+     * the {@link org.bouncycastle.crypto.StreamCipher} interface by the new
+     * instance
+     */
+    public StreamCipherAdapter(Cipher cipher, Logger parentLogger)
+    {
+        if (cipher == null)
+            throw new NullPointerException("cipher");
+
+        this.cipher = cipher;
+
+        // The value of the algorithm property of javax.crypto.Cipher is a
+        // transformation i.e. it may contain mode and padding. StreamCipher
+        // in BouncyCastle includes mode but not padding.
+        String algorithmName = cipher.getAlgorithm();
+        String cipherName = null, modeName = null;
+
+        if (algorithmName != null)
+        {
+            int endIndex = algorithmName.indexOf('/');
+
+            if (endIndex > 0)
+            {
+                cipherName = algorithmName.substring(0, endIndex);
+
+                int endIndex2 = algorithmName.indexOf('/', endIndex + 1);
+                if (endIndex2 != -1)
+                {
+                    modeName = algorithmName.substring(endIndex + 1, endIndex2);
+                }
+            }
+
+            int len = cipherName.length();
+
+            if ((len > 4)
+                && (cipherName.endsWith("_128")
+                || cipherName.endsWith("_192")
+                || cipherName.endsWith("_256")))
+            {
+                cipherName = cipherName.substring(0, len - 4);
+            }
+
+        }
+        if (cipherName != null && modeName != null)
+        {
+            this.algorithmName = cipherName + "/" + modeName;
+        }
+        else
+        {
+            this.algorithmName = cipherName;
+        }
+        this.cipherName = cipherName;
+    }
+
+    /**
+     * The last value of forEncryption passed to {@link #init}.
+     */
+    private int opMode = -1;
+
+    /**
+     * The last value of params passed, for {@link #reset}.
+     */
+    private IvParameterSpec iv = null;
+
+    @Override
+    public void init(boolean forEncryption, CipherParameters params)
+        throws IllegalArgumentException
+    {
+        if (!(params instanceof ParametersWithIV)) {
+            throw new IllegalArgumentException();
+        }
+        iv = new IvParameterSpec(((ParametersWithIV)params).getIV());
+
+        Key key;
+
+        if (((ParametersWithIV)params).getParameters() instanceof KeyParameter) {
+            KeyParameter kP = (KeyParameter)((ParametersWithIV)params).getParameters();
+            key = new SecretKeySpec(kP.getKey(), cipherName);
+        }
+        else {
+            key = null;
+        }
+
+        opMode = forEncryption ? Cipher.ENCRYPT_MODE : Cipher.DECRYPT_MODE;
+
+        try
+        {
+            cipher.init(opMode, key, iv);
+        }
+        catch (InvalidKeyException | InvalidAlgorithmParameterException e)
+        {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    @Override
+    public String getAlgorithmName()
+    {
+        return algorithmName;
+    }
+
+    private byte[] buf = null;
+
+    @Override
+    public byte returnByte(byte in)
+    {
+        if (buf == null)
+        {
+            buf = new byte[1];
+        }
+        buf[0] = in;
+        byte[] result = cipher.update(buf);
+        return result[0];
+    }
+
+    @Override
+    public int processBytes(byte[] in, int inOff, int len, byte[] out,
+        int outOff) throws DataLengthException
+    {
+        try
+        {
+            return cipher.update(in, inOff, len, out, outOff);
+        }
+        catch (ShortBufferException e)
+        {
+            throw new DataLengthException(e.getMessage());
+        }
+    }
+
+    @Override
+    public void reset()
+    {
+        try
+        {
+            /* A null key means keep the old key for all the ciphers I've checked. */
+            cipher.init(opMode, null, iv);
+        }
+        catch (InvalidKeyException | InvalidAlgorithmParameterException e)
+        {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/src/main/java/org/jitsi/srtp/crypto/StreamCipherAdapter.java
+++ b/src/main/java/org/jitsi/srtp/crypto/StreamCipherAdapter.java
@@ -25,9 +25,7 @@ import java.security.*;
 
 /**
  * Adapts the {@link javax.crypto.Cipher} class to the
- * {@link org.bouncycastle.crypto.BlockCipher} interface.
- *
- * @author Lyubomir Marinov
+ * {@link org.bouncycastle.crypto.StreamCipher} interface.
  */
 public class StreamCipherAdapter
     implements StreamCipher

--- a/src/main/java/org/jitsi/srtp/crypto/StreamCipherFactory.java
+++ b/src/main/java/org/jitsi/srtp/crypto/StreamCipherFactory.java
@@ -19,20 +19,20 @@ import org.bouncycastle.crypto.*;
 
 /**
  * Defines the application programming interface (API) of a factory of
- * <tt>org.bouncycastle.crypto.BlockCipher</tt> instances.
+ * <tt>org.bouncycastle.crypto.StreamCipher</tt> instances.
  *
  * @author Lyubomir Marinov
  */
-public interface BlockCipherFactory
+public interface StreamCipherFactory
 {
     /**
-     * Initializes a new <tt>BlockCipher</tt> instance.
+     * Initializes a new <tt>StreamCipher</tt> instance.
      * @param keySize AES key size (16, 24, 32 bytes)
      *
-     * @return a new <tt>BlockCipher</tt> instance
+     * @return a new <tt>StreamCipher</tt> instance
      * @throws Exception if anything goes wrong while initializing a new
-     * <tt>BlockCipher</tt> instance
+     * <tt>StreamCipher</tt> instance
      */
-    public BlockCipher createBlockCipher(int keySize)
+    public StreamCipher createStreamCipher(int keySize)
         throws Exception;
 }

--- a/src/test/java/org/jitsi/srtp/SrtpCipherCtrTest.java
+++ b/src/test/java/org/jitsi/srtp/SrtpCipherCtrTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.util.*;
 import javax.xml.bind.*;
 import org.bouncycastle.crypto.engines.*;
+import org.bouncycastle.crypto.modes.*;
 import org.jitsi.srtp.crypto.*;
 import org.junit.jupiter.api.*;
 
@@ -47,7 +48,7 @@ public class SrtpCipherCtrTest
     @Test
     public void testJavaCtrAes()
     {
-        SrtpCipherCtr cipher = new SrtpCipherCtrJava(new AESEngine());
+        SrtpCipherCtr cipher = new SrtpCipherCtrJava(new SICBlockCipher(new AESEngine()));
         cipher.init(TV_Key);
         byte[] data = new byte[TV_Cipher_AES_1.length];
 

--- a/src/test/java/org/jitsi/srtp/SrtpPerfTest.java
+++ b/src/test/java/org/jitsi/srtp/SrtpPerfTest.java
@@ -113,8 +113,8 @@ public class SrtpPerfTest {
 
     private static final int DEFAULT_NUM_TESTS = 100000;
     private static final int DEFAULT_PAYLOAD_SIZE = 1250;
+    /* 10000 is is the threshold for full (C2) JIT optimization. */
     private static final int DEFAULT_NUM_WARMUPS = 20000;
-    /* Allegedly, 10000 is is the threshold for JIT optimization */
 
     @Test
     public void srtpPerf()

--- a/src/test/java/org/jitsi/srtp/SrtpPerfTest.java
+++ b/src/test/java/org/jitsi/srtp/SrtpPerfTest.java
@@ -155,7 +155,7 @@ public class SrtpPerfTest {
                         payloadSize = Integer.parseInt(arg);
                     }
                     catch (NumberFormatException e) {
-                        System.err.println("Invalid payload size " + arg);
+                        System.err.println("Invalid payload size " + arg + ": " + e.getMessage());
                         usage();
                     }
                     if (payloadSize < 0) {


### PR DESCRIPTION
Should make the native crypto faster, and avoids rolling our own implementation of CTR mode.