### PR TITLE
Only return AUTH_FAIL for GCM if the cipher threw AEADBadTagException.

### DIFF
--- a/src/main/java/org/jitsi/srtp/SrtcpCryptoContext.java
+++ b/src/main/java/org/jitsi/srtp/SrtcpCryptoContext.java
@@ -260,7 +260,7 @@ public class SrtcpCryptoContext
                 int aadLen = pkt.getLength() - bufferedTagLen;
                 if (aadLen < 0)
                 {
-                    return SrtpErrorStatus.AUTH_FAIL;
+                    return SrtpErrorStatus.INVALID_PACKET;
                 }
                 cipher.processAAD(pkt.getBuffer(), pkt.getOffset(), aadLen);
                 writeRoc(index);
@@ -276,12 +276,20 @@ public class SrtcpCryptoContext
         {
             if (encrypting)
             {
-                logger.debug(() -> "Error encrypting SRTCP packet: " + e.getMessage());
+                logger.info(() -> "Error encrypting SRTCP packet: " + e.getMessage());
                 return SrtpErrorStatus.FAIL;
             }
             else
             {
-                return SrtpErrorStatus.AUTH_FAIL;
+                if (e instanceof AEADBadTagException)
+                {
+                    return SrtpErrorStatus.AUTH_FAIL;
+                }
+                else
+                {
+                    logger.info(() -> "Error decrypting SRTCP packet: " + e.getMessage());
+                    return SrtpErrorStatus.FAIL;
+                }
             }
         }
         return SrtpErrorStatus.OK;

--- a/src/main/java/org/jitsi/srtp/SrtpCryptoContext.java
+++ b/src/main/java/org/jitsi/srtp/SrtpCryptoContext.java
@@ -458,7 +458,15 @@ public class SrtpCryptoContext
             }
             else
             {
-                return SrtpErrorStatus.AUTH_FAIL;
+                if (e instanceof AEADBadTagException)
+                {
+                    return SrtpErrorStatus.AUTH_FAIL;
+                }
+                else
+                {
+                    logger.debug(() -> "Error decrypting SRTP packet: " + e.getMessage());
+                    return SrtpErrorStatus.FAIL;
+                }
             }
         }
         return SrtpErrorStatus.OK;

--- a/src/main/java/org/jitsi/srtp/SrtpCryptoContext.java
+++ b/src/main/java/org/jitsi/srtp/SrtpCryptoContext.java
@@ -453,7 +453,7 @@ public class SrtpCryptoContext
         {
             if (encrypting)
             {
-                logger.debug(() -> "Error encrypting SRTP packet: " + e.getMessage());
+                logger.info(() -> "Error encrypting SRTP packet: " + e.getMessage());
                 return SrtpErrorStatus.FAIL;
             }
             else
@@ -464,7 +464,7 @@ public class SrtpCryptoContext
                 }
                 else
                 {
-                    logger.debug(() -> "Error decrypting SRTP packet: " + e.getMessage());
+                    logger.info(() -> "Error decrypting SRTP packet: " + e.getMessage());
                     return SrtpErrorStatus.FAIL;
                 }
             }


### PR DESCRIPTION
Log other failures.

This lets us distinguish true authentication failures from other invalid cipher states.