### PR TITLE
fix: update SunPKCS11 provider creation for JDK 11+

### DIFF
--- a/src/main/java/org/jitsi/srtp/crypto/Aes.java
+++ b/src/main/java/org/jitsi/srtp/crypto/Aes.java
@@ -876,33 +876,28 @@ public class Aes
             if ((provider == null) && useProvider)
             {
                 try
-                {
-                    Class<?> clazz
-                        = Class.forName("sun.security.pkcs11.SunPKCS11");
+{
+    Provider prototype = Security.getProvider("SunPKCS11");
+    if (prototype != null)
+    {
+        String name = null;
+        Package pkg = Aes.class.getPackage();
 
-                    if (Provider.class.isAssignableFrom(clazz))
-                    {
-                        Constructor<?> contructor
-                            = clazz.getConstructor(String.class);
+        if (pkg != null)
+            name = pkg.getName();
+        if (name == null || name.length() == 0)
+            name = "org.jitsi.srtp";
 
-                        // The SunPKCS11 Config name should be unique in order
-                        // to avoid repeated initialization exceptions.
-                        String name = null;
-                        Package pkg = Aes.class.getPackage();
+        String config = "--name=" + name + "\nnssDbMode=noDb\nattributes=compatibility";
 
-                        if (pkg != null)
-                            name = pkg.getName();
-                        if (name == null || name.length() == 0)
-                            name = "org.jitsi.srtp";
+        Method configureMethod = prototype.getClass()
+            .getMethod("configure", String.class);
+        provider = (Provider) configureMethod.invoke(prototype, config);
 
-                        provider
-                            = (Provider)
-                                contructor.newInstance(
-                                        "--name=" + name + "\\n"
-                                            + "nssDbMode=noDb\\n"
-                                            + "attributes=compatibility");
-                    }
-                }
+        if (provider != null)
+            Security.addProvider(provider);
+    }
+}
                 finally
                 {
                     if (provider == null)


### PR DESCRIPTION
## Problem
On JDK 11+, the SunPKCS11 provider creation fails because the  constructor that accepts a config string was removed in JDK 11. This causes the AES PKCS11 cipher factory to silently fail and  fall back to a slower implementation.

## Fix
- Use Security.getProvider("SunPKCS11") instead of Class.forName constructor
- Call configure() method via reflection (JDK 11+ approach)
- Register the provider with Security.addProvider()
- Fix config string to use actual newlines instead of literal \n