### PR TITLE
Pin GitHub Actions to SHA hashes

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,10 +29,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
@@ -43,13 +43,13 @@ jobs:
 
       - name: Upload coverage report
         if: matrix.java == env.RELEASE_JAVA_VERSION
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe  # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload JNI headers
         if: matrix.java == env.RELEASE_JAVA_VERSION
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
         with:
           name: javah
           path: target/native
@@ -70,10 +70,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Get JNI headers
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: javah
           path: target/native
@@ -82,7 +82,7 @@ jobs:
         run: resources/ubuntu-build-docker.sh ${{ matrix.arch }} ${{ matrix.dist.dist }} ${{ env.RELEASE_JAVA_VERSION }} ${{ matrix.dist.libssl }}
 
       - name: Upload lib as artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
         with:
           name: native-ubuntu-${{ matrix.dist.dist }}-${{ matrix.arch }}
           path: src/main/resources/*
@@ -102,17 +102,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Get JNI headers
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: javah
           path: target/native
 
       - name: Set up JDK ${{ env.RELEASE_JAVA_VERSION }}
         id: install_java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5
         with:
           distribution: zulu
           java-version: ${{ env.RELEASE_JAVA_VERSION }}
@@ -125,7 +125,7 @@ jobs:
         run: resources/mac-cmake.sh "${{ steps.install_java.outputs.path }}" "${{ matrix.arch.arch }}" "${{ matrix.libssl }}"
 
       - name: Upload lib as artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
         with:
           name: native-darwin-${{ matrix.arch.arch }}-${{ matrix.libssl }}
           path: src/main/resources/*
@@ -139,12 +139,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 0
 
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5
         with:
           distribution: temurin
           java-version: ${{ env.RELEASE_JAVA_VERSION }}
@@ -154,7 +154,7 @@ jobs:
           server-password: SONATYPE_PW
 
       - name: Download natives
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6
         with:
           path: target
           pattern: native-*
@@ -186,7 +186,7 @@ jobs:
         run: mvn -B test -Dosgi-native=true
 
       - name: Attach final jars (if PR)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
         if: github.ref != 'refs/heads/master'
         with:
           name: jars
@@ -211,7 +211,7 @@ jobs:
             deploy
 
       - name: Attach final jars (after releasing to Maven Central)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
         if: github.ref == 'refs/heads/master'
         with:
           name: jars


### PR DESCRIPTION
Pin all GitHub Actions version tags to their corresponding commit SHA hashes for improved supply-chain security.

Original version tags are preserved as comments (e.g. `# v4`).